### PR TITLE
Changed domain regex

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -143,7 +143,7 @@ class App extends Component {
     // Transform http to https
     url = url.replace("http://", "https://");
     
-    const domain = url.match(/:\/\/(.+)\//)[1];
+    const domain = url.match(/:\/\/([^/]+)/)[1];
     const extPattern = /\.[0-9a-z]+$/i;
     const match = url.match(extPattern);
     const fileExt = match ? match[0] : null;


### PR DESCRIPTION
Sometimes the post has a URL that just points to a domain without the trailing slash. This would cause an error as the regex didn't match anything in these cases causing the slideshow to break for a subreddit.